### PR TITLE
fix: replace relative imports with absolute

### DIFF
--- a/queue-writer/api/auth.py
+++ b/queue-writer/api/auth.py
@@ -7,7 +7,7 @@ import logging
 from pathlib import Path
 from typing import Optional
 
-from ..domain.ports import TokenValidator, AuthenticationError
+from domain.ports import TokenValidator, AuthenticationError
 
 
 logger = logging.getLogger(__name__)

--- a/queue-writer/api/http_server.py
+++ b/queue-writer/api/http_server.py
@@ -12,9 +12,9 @@ from fastapi.responses import JSONResponse
 from fastapi.middleware.cors import CORSMiddleware
 import uvicorn
 
-from ..domain.ports import QueueWriter, TokenValidator, AuthenticationError
-from ..domain.schema import TelegramEvent, QueueWriteResult, HealthStatus
-from .auth import AuthDependency
+from domain.ports import QueueWriter, TokenValidator, AuthenticationError
+from domain.schema import TelegramEvent, QueueWriteResult, HealthStatus
+from api.auth import AuthDependency
 
 
 logger = logging.getLogger(__name__)

--- a/queue-writer/infra/redis_writer.py
+++ b/queue-writer/infra/redis_writer.py
@@ -10,8 +10,8 @@ from typing import Optional
 
 from redis.exceptions import RedisError
 
-from ..domain.ports import QueueWriter, QueueWriteError
-from ..domain.schema import TelegramEvent, QueueWriteResult, HealthStatus
+from domain.ports import QueueWriter, QueueWriteError
+from domain.schema import TelegramEvent, QueueWriteResult, HealthStatus
 from .redis_client import RedisClient
 
 


### PR DESCRIPTION
## Summary
- use absolute imports instead of package-relative imports in queue-writer modules to avoid ImportError

## Testing
- `python -m py_compile infra/redis_writer.py api/auth.py api/http_server.py`
- `timeout 5s python app.py` *(fails: Error -2 connecting to redis:6379. -2)*

------
https://chatgpt.com/codex/tasks/task_e_68bfd9749fc88323b7fc779f1aebbf2b